### PR TITLE
Release v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## PENDING RELEASE - 0.0.8
+## 2024-02-07 - 0.0.8
 
 Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## PENDING RELEASE - 0.0.8
+
+Fixes:
+
+- Log file `count` option was not being used at all; log files would rotate but never be cleaned up.
+
 ## 2024-01-31 - 0.0.7
 
 Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Fixes:
 
-- Log file `count` option was not being used at all; log files would rotate but never be cleaned up.
+- Log file `count` option was not being used at all; log files would rotate but never be cleaned up
+- If a `host` value was provided for the `http` check method the value was being ignored; the host was overwritten from the hostname in URL
 
 ## 2024-01-31 - 0.0.7
 

--- a/exacheck/logmanager.py
+++ b/exacheck/logmanager.py
@@ -202,6 +202,7 @@ class LogManager:
                 compression=compression,
                 enqueue=True,
                 filter=log_filter,
+                retention=config.count,
             )
 
         # Set the logger ID for the config

--- a/exacheck/settings/checkargs/httpargs.py
+++ b/exacheck/settings/checkargs/httpargs.py
@@ -169,7 +169,7 @@ class HTTPArgs(Remote):
             return values
 
         # Skip if a host value was provided
-        if "host" in values and values["host"] is None:
+        if "host" in values and values["host"] is not None:
             return values
 
         # Attempt to parse the URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "exacheck"
 description = "ExaCheck - ExaBGP Health Checker"
 authors = ["Chris <info@exacheck.net>"]
-version = "0.0.7"
+version = "0.0.8"
 readme = "README.md"
 homepage = "https://exacheck.net"
 repository = "https://github.com/exacheck/exacheck"

--- a/schema.json
+++ b/schema.json
@@ -554,7 +554,7 @@
                     "title": "HTTP Timeout"
                 },
                 "user_agent": {
-                    "default": "ExaCheck HTTP Health Check [v0.0.7]",
+                    "default": "ExaCheck HTTP Health Check [v0.0.8]",
                     "description": "The user agent to send with the HTTP request",
                     "title": "User Agent",
                     "type": "string"


### PR DESCRIPTION
Fixes:

- Log file `count` option was not being used at all; log files would rotate but never be cleaned up
- If a `host` value was provided for the `http` check method the value was being ignored; the host was overwritten from the hostname in URL