### PR TITLE
Release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## PENDING RELEASE - 0.0.9
+
+Fixes:
+
+- `http` check method fails to parse the URL correctly for IPv6 hosts; IPv6 address must be enclosed with `[]`
+
 ## 2024-02-07 - 0.0.8
 
 Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## PENDING RELEASE - 0.0.9
+## 2024-02-07 - 0.0.9
 
 Fixes:
 

--- a/exacheck/methods/http.py
+++ b/exacheck/methods/http.py
@@ -8,7 +8,7 @@ Check Method - HTTP
 
 import warnings
 from pprint import pformat
-from ipaddress import ip_address
+from ipaddress import ip_address, IPv6Address
 
 import requests
 
@@ -190,6 +190,10 @@ class HTTP(Remote):
             path = self.args.url.path
         else:
             path = "/"
+
+        # If the IP address to test is an IPv6 IP, enclose it with square brackets
+        if isinstance(ip_address(addr), IPv6Address):
+            addr = f"[{addr}]"
 
         # Generate the URL
         url = template.format(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "exacheck"
 description = "ExaCheck - ExaBGP Health Checker"
 authors = ["Chris <info@exacheck.net>"]
-version = "0.0.8"
+version = "0.0.9"
 readme = "README.md"
 homepage = "https://exacheck.net"
 repository = "https://github.com/exacheck/exacheck"

--- a/schema.json
+++ b/schema.json
@@ -554,7 +554,7 @@
                     "title": "HTTP Timeout"
                 },
                 "user_agent": {
-                    "default": "ExaCheck HTTP Health Check [v0.0.8]",
+                    "default": "ExaCheck HTTP Health Check [v0.0.9]",
                     "description": "The user agent to send with the HTTP request",
                     "title": "User Agent",
                     "type": "string"


### PR DESCRIPTION
Fixes:

- `http` check method fails to parse the URL correctly for IPv6 hosts; IPv6 address must be enclosed with `[]`